### PR TITLE
Inla dependency

### DIFF
--- a/ModGP MASTER.R
+++ b/ModGP MASTER.R
@@ -26,7 +26,7 @@ message(sprintf("SPECIES = %s", SPECIES))
 install.load.package <- function(x) {
 	if (!require(x, character.only = TRUE))
 		install.packages(x, repos='http://cran.us.r-project.org')
-	require(x, character.only = TRUE)
+	library(x, character.only = TRUE)
 }
 ### CRAN PACKAGES ----
 package_vec <- c(

--- a/ModGP MASTER.R
+++ b/ModGP MASTER.R
@@ -43,7 +43,6 @@ package_vec <- c(
 	"pbapply", # for parallelised apply functions and estimators
 	"devtools", # for non-CRAN installation
 	"remotes", # for non-CRAN installation
-	"INLA", # for pointedSDMs
 	# "intSDM", # for intSDMs
 	"giscoR", # for shapefiles of Earth
 	"Epi", # for ROC statistic
@@ -64,6 +63,11 @@ package_vec <- c(
 sapply(package_vec, install.load.package)
 
 ### NON-CRAN PACKAGES ----
+if("INLA" %in% rownames(installed.packages()) == FALSE){ # for pointed SDMs
+    install.packages("INLA", repos="https://inla.r-inla-download.org/R/stable", dependencies=TRUE)
+}
+library(INLA)
+
 if("KrigR" %in% rownames(installed.packages()) == FALSE){ # KrigR check
 	Sys.setenv(R_REMOTES_NO_ERRORS_FROM_WARNINGS="true")
 	remotes::install_github("https://github.com/cran/rgdal")


### PR DESCRIPTION
Hi,

when I tried to run `ModGP MASTER.R`, it failed to resolve the package `INLA`. According to https://www.r-inla.org/download-install, INLA is not available via CRAN (anymore?).

I updated the script to load `INLA` from it's own repository as suggested by the installation page of the package.