### PR TITLE
Increase job time allocation to 24 hours

### DIFF
--- a/submit_modgp_prep_lumi.sh
+++ b/submit_modgp_prep_lumi.sh
@@ -5,7 +5,7 @@
 #SBATCH --nodes=1
 #SBATCH --tasks-per-node=1
 #SBATCH --cpus-per-task=8
-#SBATCH --time=12:00:00
+#SBATCH --time=24:00:00
 #SBATCH --partition=small --mem=64G
 ##SBATCH --partition=standard --exclusive --mem=0
 ##SBATCH --partition=debug --exclusive --mem=0 --time=0:30:00


### PR DESCRIPTION
My latest run of data prep script got halted because it ran out of time. I increased the time to 24 hours.