### PR TITLE
Add instructions for credentials file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # uc-CWR
 
+## Initial setup
+
+1. Create a file `R_scripts/SHARED-APICredentials.R`. You can use [the example file](R_scripts/SHARED-APICredentials.example.R) as a template. Insert your [CDS API key](https://cds.climate.copernicus.eu/how-to-api) and [GBIF credentials](https://www.gbif.org/) in this file.
+
 ## ModGP on Rstudio
 
 1. Source `ModGP_MASTER.R` and change `SPECIES` argument at line 19 to execute ModGP pipeline for a specific genus.

--- a/R_scripts/SHARED-APICredentials.example.R
+++ b/R_scripts/SHARED-APICredentials.example.R
@@ -1,0 +1,7 @@
+# CDS
+API_Key <- "..."
+
+# GBIF
+options(gbif_user = "...")
+options(gbif_email = "...")
+options(gbif_pwd = "...")


### PR DESCRIPTION
This PR will add an example file and instructions for creating the `SHARED-APICredentials.R` file.